### PR TITLE
Corrected Japanese cat and wrote docu text

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ interchangeable in Meowlang programs.
 * `Miaou` in French
 * `喵` in Chinese
 * `Miao` in Chinese Pinyin
+* `Miau` in German
+* `ニャー` in Japanese Katakana (Katakana because its onomatopoeia)
 
 Meow tokens are case-insensitive. For example, `Meow`, `meow`, and `MEOW` are
 the same things.

--- a/meowlang.js
+++ b/meowlang.js
@@ -28,7 +28,7 @@ export const MEOW_TOKENS = {
   de: 'Miau',
   en: 'Meow',
   fr: 'Miaou',
-  jp: 'にゃん',
+  jp: 'ニャー',
   zh: '喵',
   py: 'Miao',
 };


### PR DESCRIPTION
i had forgotten to mention the changes in the readme and i noticed that the japanese was in Hiragana writing but should be in Katakana because it's Onomatopoeia