### PR TITLE
fix(deps): pin postcss >= 8.5.18 to fix source map path traversal

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "yargs": "^17.7.2"
   },
   "resolutions": {
-    "portfinder": "^1.0.38"
+    "portfinder": "^1.0.38",
+    "postcss": "^8.5.18"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1361,10 +1361,10 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.11:
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
-  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+nanoid@^3.3.16:
+  version "3.3.16"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
+  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -1465,12 +1465,12 @@ portfinder@^1.0.28, portfinder@^1.0.38:
     async "^3.2.6"
     debug "^4.3.6"
 
-postcss@^8.5.6:
-  version "8.5.9"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.9.tgz#f6ee9e0b94f0f19c97d2f172bfbd7fc71fe1cca4"
-  integrity sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==
+postcss@^8.5.18, postcss@^8.5.6:
+  version "8.5.25"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.25.tgz#5012a598eaaa897f21bbe8553be3cb7bd2bd78cb"
+  integrity sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==
   dependencies:
-    nanoid "^3.3.11"
+    nanoid "^3.3.16"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 


### PR DESCRIPTION
postcss arrives transitively as a dev-only dependency via vitest -> vite -> postcss@^8.5.6, which resolved to 8.5.9. Versions <= 8.5.17 auto-load a previous source map from an attacker-controlled sourceMappingURL comment without sandboxing the resolved path, allowing arbitrary .map file disclosure via path traversal.

yarn upgrade only touches direct dependencies, so add a resolutions entry (matching the existing portfinder pattern) to force the patched version. Resolves to 8.5.25 and bumps nanoid 3.3.11 -> 3.3.16.